### PR TITLE
Bump Phoenix 6 vendordep and fix Aim sim

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -187,6 +187,7 @@ public class Constants {
             private static final double kP = 0.01; // idk
             private static final double kS = 0;
             private static final double kG = 0;
+            private static final double kV = 0;
             private static final double kAcceleration = 160;
 
             public static final TalonFXConfiguration motorConfig = new TalonFXConfiguration();
@@ -197,6 +198,7 @@ public class Constants {
                     .withKP(kP)
                     .withKS(kS)
                     .withKG(kG)
+                    .withKV(kV)
                     .withGravityType(GravityTypeValue.Arm_Cosine);
 
                 motorConfig.Feedback = motorConfig.Feedback
@@ -217,9 +219,9 @@ public class Constants {
                     .withSupplyCurrentLimitEnable(true);
 
                 motorConfig.MotionMagic = motorConfig.MotionMagic
-                    .withMotionMagicCruiseVelocity(20)
-                    .withMotionMagicAcceleration(kAcceleration)
-                    .withMotionMagicJerk(400);
+                    .withMotionMagicCruiseVelocity(20 / kGearRatio)
+                    .withMotionMagicAcceleration(kAcceleration / kGearRatio)
+                    .withMotionMagicJerk(400 / kGearRatio);
 
                 motorConfig.HardwareLimitSwitch = motorConfig.HardwareLimitSwitch
                     .withForwardLimitEnable(false)

--- a/vendordeps/Phoenix6.json
+++ b/vendordeps/Phoenix6.json
@@ -1,13 +1,13 @@
 {
     "fileName": "Phoenix6.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "24.1.0-45-g0e8c329",
+    "version": "24.2.0",
     "frcYear": 2024,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
-        "https://maven.ctr-electronics.com/development/"
+        "https://maven.ctr-electronics.com/release/"
     ],
-    "jsonUrl": "https://maven.ctr-electronics.com/development/com/ctre/phoenix6/latest/Phoenix6-frc2024-latest.json",
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2024-latest.json",
     "conflictsWith": [
         {
             "uuid": "3fcf3402-e646-4fa6-971e-18afe8173b1a",
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "24.1.0-45-g0e8c329"
+            "version": "24.2.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -39,7 +39,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -52,7 +52,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -65,7 +65,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -78,7 +78,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -91,7 +91,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -104,7 +104,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -117,7 +117,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -130,7 +130,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -143,7 +143,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -173,7 +173,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -188,7 +188,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -203,7 +203,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -218,7 +218,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -233,7 +233,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -248,7 +248,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -263,7 +263,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -278,7 +278,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -293,7 +293,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -323,7 +323,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.1.0-45-g0e8c329",
+            "version": "24.2.0",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
- Bumped the Phoenix 6 vendordep to the latest stable (24.2.0)
- Fix Motion Magic configs so cruise velocity/acceleration/jerk are properly scaled with gear ratio; the Motion Magic configs operate on the position/velocity after the RotorToSensorRatio and SensorToMechanismRatio
- Fix initial position of Aim in simulation
- Fix `Aim.simulationPeriodic()`